### PR TITLE
refactor(protocol): change nomenclature

### DIFF
--- a/protocol/faq/basics.md
+++ b/protocol/faq/basics.md
@@ -8,8 +8,8 @@ sidebar_position: 1
 
 You can access Sablier through our branded web interfaces:
 
-- [pay.sablier.finance](https://pay.sablier.finance) (streaming money)
-- [app.sablier.finance](https://app.sablier.finance) (withdrawing the streamed money)
+- [pay.sablier.finance](https://pay.sablier.finance) (streaming tokens)
+- [app.sablier.finance](https://app.sablier.finance) (withdrawing the streamed tokens)
 - [gnosis-safe.io](https://gnosis-safe.io)
 
 We're working with various projects in the DeFi ecosystem to make Sablier accessible through more and more interfaces.
@@ -19,16 +19,16 @@ If you want to use Sablier on a testnet, you may have to get some [TestnetDAI](.
 
 A term coined by us to emphasize the wide-ranging use cases for the Sablier protocol. We like to think about work as an attempt to rethink the way trust is established in financial contracts.
 
-### What is money streaming?
+### What is token streaming?
 
-An alternative wording, [coined](https://www.youtube.com/watch?v=gF_ZQ_eijPs) by Andreas Antonopoulos in 2017. Just like you can stream movies on Netflix or music on Spotify, so you can stream money by the second on Sablier.
+An alternative wording, [coined](https://www.youtube.com/watch?v=gF_ZQ_eijPs) by Andreas Antonopoulos in 2017. Just like you can stream movies on Netflix or music on Spotify, so you can stream tokens by the second on Sablier.
 
 ### How does streaming work on Sablier?
 
-Imagine a salary worth 3,000 DAI paid by Alice to Bob over the whole month of January.
+Imagine Alice wants to send 3,000 DAI over to Bob during the whole month of January.
 
 1. Alice makes the 3,000 DAI deposit in the Sablier contract _before_ Jan 1, setting the stop time to Feb 1.
-2. Every second beginning Jan 1 makes Bob richer.
+2. Bob's crypto earnings increase every second beginning Jan 1.
 3. On Jan 10, Bob will have earned approximately 1,000 DAI.
-4. If at any point during January Alice wishes to recover her money, she can cancel the stream and recover what
+4. If at any point during January Alice wishes to recover her tokens, she can cancel the stream and recover what
    has not been streamed yet.

--- a/protocol/faq/basics.md
+++ b/protocol/faq/basics.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ### Where can I access the Sablier protocol?
 
-You can access Sablier through our branded web interfaces:
+You can access Sablier through the following web interfaces:
 
 - [pay.sablier.finance](https://pay.sablier.finance) (streaming tokens)
 - [app.sablier.finance](https://app.sablier.finance) (withdrawing the streamed tokens)
@@ -25,9 +25,9 @@ An alternative wording, [coined](https://www.youtube.com/watch?v=gF_ZQ_eijPs) by
 
 ### How does streaming work on Sablier?
 
-Imagine Alice wants to send 3,000 DAI over to Bob during the whole month of January.
+Imagine Alice wants to make a 3,000 DAI payment to Bob during the whole month of January.
 
-1. Alice makes the 3,000 DAI deposit in the Sablier contract _before_ Jan 1, setting the stop time to Feb 1.
+1. Alice deposits the 3,000 DAI in Sablier _before_ Jan 1, setting the stop time to Feb 1.
 2. Bob's crypto earnings increase every second beginning Jan 1.
 3. On Jan 10, Bob will have earned approximately 1,000 DAI.
 4. If at any point during January Alice wishes to recover her tokens, she can cancel the stream and recover what

--- a/protocol/faq/technical-glossary.md
+++ b/protocol/faq/technical-glossary.md
@@ -37,11 +37,11 @@ Sablier is compatible with ERC-20 tokens only, such as [DAI](https://makerdao.co
 
 A real-time payment, made up of six properties:
 
-| Name       | Description                      |
-| ---------- | -------------------------------  |
-| Sender     | Ethereum address                 |
-| Recipient  | Ethereum address                 |
-| Deposit    | Total amount of tokens to stream |
-| Token      | ERC-20 token address             |
-| Start time | When the token streaming starts  |
-| Stop time  | When the token streaming stops   |
+| Name       | Description                                  |
+| ---------- | -------------------------------------------- |
+| Sender     | Ethereum address                             |
+| Recipient  | Ethereum address                             |
+| Deposit    | Total amount of tokens to stream             |
+| Token      | ERC-20 token address                         |
+| Start time | The Unix timestamp when the streaming starts |
+| Stop time  | The Unix timestamp when the streaming stops  |

--- a/protocol/faq/technical-glossary.md
+++ b/protocol/faq/technical-glossary.md
@@ -37,11 +37,11 @@ Sablier is compatible with ERC-20 tokens only, such as [DAI](https://makerdao.co
 
 A real-time payment, made up of six properties:
 
-| Name       | Description                     |
-| ---------- | ------------------------------- |
-| Sender     | Ethereum address                |
-| Recipient  | Ethereum address                |
-| Deposit    | Total amount of money to stream |
-| Token      | ERC-20 token address            |
-| Start time | When the money streaming starts |
-| Stop time  | When the money streaming stops  |
+| Name       | Description                      |
+| ---------- | -------------------------------  |
+| Sender     | Ethereum address                 |
+| Recipient  | Ethereum address                 |
+| Deposit    | Total amount of tokens to stream |
+| Token      | ERC-20 token address             |
+| Start time | When the token streaming starts  |
+| Stop time  | When the token streaming stops   |

--- a/protocol/faq/token-streaming.md
+++ b/protocol/faq/token-streaming.md
@@ -1,6 +1,6 @@
 ---
-id: money-streaming
-title: Money Streaming
+id: token-streaming
+title: Token Streaming
 sidebar_position: 3
 ---
 
@@ -22,7 +22,7 @@ In our web interface, the start time is automatically set to ~15 minutes after t
 
 ### How does streaming work?
 
-Dividing the deposit amount by the difference between the stop time and the start time gives us a payment rate per second. Sablier uses this rate to transfer a little bit of money from the sender to the recipient once every second.
+Dividing the deposit amount by the difference between the stop time and the start time gives us a payment rate per second. Sablier uses this rate to transfer a small portion of tokens from the sender to the recipient once every second.
 
 For instance, if the payment rate was 0.01 DAI per second, the recipient would receive:
 
@@ -30,13 +30,13 @@ For instance, if the payment rate was 0.01 DAI per second, the recipient would r
 - 0.01 \* 60 \* 60 = 36 DAI / hour
 - 0.01 \* 60 \* 60 \* 24 = 864 DAI / day
 
-### Where is the money held?
+### Where are the tokens held?
 
 In our smart contracts. You can verify this assertion by inspecting [Etherscan](https://etherscan.io/address/0xcd18eaa163733da39c232722cbc4e8940b1d8888) or any other blockchain explorer.
 
-### How can recipients access their money?
+### How can recipients access their tokens?
 
-As the money is being streamed at the smart contract level, recipients can consider Sablier their real-time wallet for digital currency.
+As the tokens are being streamed at the smart contract level, recipients can consider Sablier their real-time wallet for digital currency.
 
 To make withdrawals, recipients can:
 

--- a/protocol/faq/token-streaming.md
+++ b/protocol/faq/token-streaming.md
@@ -32,7 +32,7 @@ For instance, if the payment rate was 0.01 DAI per second, the recipient would r
 
 ### Where are the tokens held?
 
-In our smart contracts. You can verify this assertion by inspecting [Etherscan](https://etherscan.io/address/0xcd18eaa163733da39c232722cbc4e8940b1d8888) or any other blockchain explorer.
+In our smart contracts. You can verify this assertion by inspecting [Etherscan](https://etherscan.io/address/0xCD18eAa163733Da39c232722cBC4E8940b1D8888) or any other blockchain explorer.
 
 ### How can recipients access their tokens?
 

--- a/protocol/guides/codebase.mdx
+++ b/protocol/guides/codebase.mdx
@@ -14,7 +14,7 @@ The Sablier protocol is hosted on GitHub and the source code for each contract i
   href="https://github.com/sablierhq/sablier"
   icon="github"
   subtitle="GitHub"
-  title="Github - sablierhq/sablier: Money streaming protocol"
+  title="Github - sablierhq/sablier: Token streaming protocol"
 />
 
 ## ABIs

--- a/protocol/introduction.md
+++ b/protocol/introduction.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # What is Sablier?
 
-Sablier is a money streaming protocol available on Ethereum, Optimism, Arbitrum, Polygon, Ronin, Avalanche, and BSC. It's the first of its kind to have ever been built in crypto, tracing its origins back to 2019. Similar to how you can stream a movie on Netflix or a song on Spotify, so you can stream money by the second on Sablier.
+Sablier is a token streaming protocol available on Ethereum, Optimism, Arbitrum, Polygon, Ronin, Avalanche, and BSC. It's the first of its kind to have ever been built in crypto, tracing its origins back to 2019. Similar to how you can stream a movie on Netflix or a song on Spotify, so you can stream tokens by the second on Sablier.
 
 If you're a developer, head over to the [guides](./guides/getting-started) section or check the [technical
 reference](./technical-reference/streams). Conversely, if you're just interested in learning more about Sablier from a

--- a/protocol/technical-reference/constant-functions.md
+++ b/protocol/technical-reference/constant-functions.md
@@ -15,12 +15,12 @@ function getStream(uint256 streamId) view returns (address sender, address recip
 - `streamId`: The id of the stream to query.
 - `RETURN`
   - `sender`: The address that created and funded the stream.
-  - `recipient`: The address towards which the money is streamed.
+  - `recipient`: The address towards which the tokens are streamed.
   - `tokenAddress`: The address of the ERC-20 token used as streaming currency.
   - `startTime`: The unix timestamp for when the stream starts, in seconds.
   - `stopTime`: The unix timestamp for when the stream stops, in seconds.
-  - `remainingBalance`: How much money is still allocated to this stream, in the smart contract.
-  - `ratePerSecond`: How much money is allocated from the sender to the recipient every second.
+  - `remainingBalance`: How much tokens are still allocated to this stream, in the smart contract.
+  - `ratePerSecond`: How much tokens are allocated from the sender to the recipient every second.
 
 ### Solidity
 
@@ -53,7 +53,7 @@ function balanceOf(uint256 streamId, address who) view returns (uint256)
 - `RETURN`: The available balance in units of the underlying ERC-20 token.
 
 :::info
-This is the amount of tokens that can be withdrawn from the contract, not the total amount of money streamed. If the contract streamed 1,000
+This is the amount of tokens that can be withdrawn from the contract, not the total amount of tokens streamed. If the contract streamed 1,000
 tokens to Bob, but Bob withdrew 400 tokens already, this function will return 600 and not 1,000.
 :::
 
@@ -113,22 +113,22 @@ const delta = await sablier.deltaOf(streamId);
 The table below lists all possible reasons for reverting a contract call that creates, withdraws from or cancels a
 stream. The "Id" column is just a counter used in this table - the smart contract does not yield error codes, just strings.
 
-| Number | Error                                                   | Reason                                                                                                                 |
-| ------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 1      | stream does not exist                                   | The provided stream id does not point to a valid stream                                                                |
-| 2      | caller is not the sender or the recipient of the stream | The contract call originates from an unauthorized third-party                                                          |
-| 3      | SafeERC20: low-level call failed                        | Possibly insufficient allowance, but not necessarily so                                                                |
-| 4      | stream to the zero address                              | Attempt to stream money to the [zero address](https://etherscan.io/address/0x0000000000000000000000000000000000000000) |
-| 5      | stream to the contract itself                           | Attempt to stream money to the Sablier contract                                                                        |
-| 6      | stream to the caller                                    | Happens when the caller attempts to stream money to herself                                                            |
-| 7      | deposit is zero                                         | Attempt to stream 0 tokens                                                                                             |
-| 8      | start time before block.timestamp                       | Money cannot be streamed retroactively                                                                                 |
-| 9      | stop time before the start time                         | Negative streaming is not allowed                                                                                      |
-| 10     | deposit smaller than time delta                         | The deposit, measured in units of the token, is smaller than the time delta                                            |
-| 11     | deposit not multiple of time delta                      | The deposit has a non-zero remainder when divided by the time delta                                                    |
-| 12     | amount is zero                                          | Attempt to withdraw 0 tokens                                                                                           |
-| 13     | amount exceeds the available balance                    | Attempt to withdraw more money than the available balance                                                              |
-| 14     | recipient balance calculation error                     | Happens only when streaming an absurdly high number of tokens (close to 2^256)                                         |
+| Number | Error                                                   | Reason                                                                                                                  |
+| ------ | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------  |
+| 1      | stream does not exist                                   | The provided stream id does not point to a valid stream                                                                 |
+| 2      | caller is not the sender or the recipient of the stream | The contract call originates from an unauthorized third-party                                                           |
+| 3      | SafeERC20: low-level call failed                        | Possibly insufficient allowance, but not necessarily so                                                                 |
+| 4      | stream to the zero address                              | Attempt to stream tokens to the [zero address](https://etherscan.io/address/0x0000000000000000000000000000000000000000) |
+| 5      | stream to the contract itself                           | Attempt to stream tokens to the Sablier contract                                                                        |
+| 6      | stream to the caller                                    | Happens when the caller attempts to stream tokens to herself                                                            |
+| 7      | deposit is zero                                         | Attempt to stream 0 tokens                                                                                              |
+| 8      | start time before block.timestamp                       | Tokens cannot be streamed retroactively                                                                                 |
+| 9      | stop time before the start time                         | Negative streaming is not allowed                                                                                       |
+| 10     | deposit smaller than time delta                         | The deposit, measured in units of the token, is smaller than the time delta                                             |
+| 11     | deposit not multiple of time delta                      | The deposit has a non-zero remainder when divided by the time delta                                                     |
+| 12     | amount is zero                                          | Attempt to withdraw 0 tokens                                                                                            |
+| 13     | amount exceeds the available balance                    | Attempt to withdraw more tokens than the available balance                                                              |
+| 14     | recipient balance calculation error                     | Happens only when streaming an absurdly high number of tokens (close to 2^256)                                          |
 
 :::info
 The contract call could revert with [no reason](https://vmexceptionwhileprocessingtransactionrevert.com/) provided. In this case, you probably did not approve the Sablier contract to spend your token balance, although this is not necessarily the case. Ping us on [Discord](https://discord.gg/bSwRCwWRsT) if you get stuck.

--- a/protocol/technical-reference/non-constant-functions.md
+++ b/protocol/technical-reference/non-constant-functions.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 ## Create stream
 
 The create stream function transfers the tokens into the Sablier smart contract, stamping the rules of the stream into
-the blockchain. As soon as the chain clock hits the start time of the stream, a little bit of money starts getting
+the blockchain. As soon as the chain clock hits the start time of the stream, a small portion of tokens starts getting
 "transferred" from the sender to the recipient once every second.
 
 We used scare quotes because what actually happens is not a transfer, but rather an abstract allocation of funds. Every
@@ -19,8 +19,8 @@ function createStream(address recipient, uint256 deposit, address tokenAddress, 
 ```
 
 - `msg.sender`: The account who funds the stream, and pay the recipient in real-time.
-- `recipient`: The account toward which the money will be streamed.
-- `deposit`: The amount of money to be streamed, in units of the streaming currency.
+- `recipient`: The account toward which the tokens will be streamed.
+- `deposit`: The amount of tokens to be streamed, in units of the streaming currency.
 - `tokenAddress`: The address of the ERC-20 token to use as streaming currency.
 - `startTime`: The unix timestamp for when the stream starts, in seconds.
 - `stopTime`: The unix timestamp for when the stream stops, in seconds.
@@ -87,7 +87,7 @@ await createStreamTx.wait();
 
 ## Withdraw from Stream
 
-The withdraw from stream function transfers an amount of money from the Sablier contract to the recipient's account. The
+The withdraw from stream function transfers an amount of tokens from the Sablier contract to the recipient's account. The
 withdrawn amount must be less than or equal to the available [balance](./constant-functions#balance-of). This function can only be
 called by the sender or the recipient of the stream, not any third-party.
 
@@ -95,8 +95,8 @@ called by the sender or the recipient of the stream, not any third-party.
 function withdrawFromStream(uint256 streamId, uint256 amount) returns (bool);
 ```
 
-- `streamId`: The id of the stream to withdraw money from.
-- `amount`: The amount of money to withdraw.
+- `streamId`: The id of the stream to withdraw tokens from.
+- `amount`: The amount of tokens to withdraw.
 - `RETURN`: True on success, reverts on error.
 
 :::info
@@ -126,10 +126,10 @@ await withdrawFromStreamTx.wait();
 
 ## Cancel Stream
 
-The cancel stream function revokes a previously created stream and returns the money back to the sender and/or the
-recipient. If the chain clock did not hit the start time, all the money is returned to the sender. If the chain clock did go
+The cancel stream function revokes a previously created stream and returns the tokens back to the sender and/or the
+recipient. If the chain clock did not hit the start time, all the tokens is returned to the sender. If the chain clock did go
 past the start time, but not past the stop time, the sender and the recipient each get a pro-rata amount. Finally, if
-the chain clock went past the stop time, all the money goes the recipient. This function can be called only by the sender.
+the chain clock went past the stop time, all the tokens goes the recipient. This function can be called only by the sender.
 
 ```solidity
 function cancelStream(uint256 streamId) returns (bool);

--- a/protocol/technical-reference/streams.md
+++ b/protocol/technical-reference/streams.md
@@ -4,10 +4,10 @@ title: Streams
 sidebar_position: 1
 ---
 
-Every interaction with the Sablier protocol is in relation to a specific "money stream". This is how we refer to a
+Every interaction with the Sablier protocol is in relation to a specific "token stream". This is how we refer to a
 real-time payment.
 
-A money stream has six properties:
+A token stream has six properties:
 
 1. Sender.
 2. Recipient.


### PR DESCRIPTION
Replace "money streams" by "token streams", remove the words "salary"...